### PR TITLE
allow full feature with other features

### DIFF
--- a/disarm64/src/lib.rs
+++ b/disarm64/src/lib.rs
@@ -16,12 +16,6 @@
 
 #![no_std]
 
-#[cfg(all(
-    feature = "full",
-    any(feature = "load_store", feature = "system", feature = "exception")
-))]
-compile_error!("Cannot use the 'full' feature with any of 'load_store', 'system', 'exception'");
-
 use core::fmt::Display;
 use core::fmt::Formatter;
 


### PR DESCRIPTION
Since there are no name collisions, and `cargo` features should be additive, this change should only increase compatibility, and not break anything.